### PR TITLE
Add support for binder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Yu-Group/iterative-Random-Forest/master)
+
 # iterative Random Forest
 The algorithm details are available at: 
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,13 @@
+dependencies:
+  - conda-forge::numpy=1.19.1
+  - conda-forge::scipy=1.5.2
+  - conda-forge::matplotlib=3.3.0
+  - conda-forge::scikit-learn=0.23.1
+  - conda-forge::pyyaml=5.3.1
+  - conda-forge::pydotplus=2.0.2
+  - conda-forge::cython=0.29.21
+  - conda-forge::pyspark=2.4.0
+  - conda-forge::pyfpgrowth=1.0
+  - pip:
+    - git+https://github.com/Yu-Group/iterative-Random-Forest.git@11778e4
+


### PR DESCRIPTION
Per meeting with Bin and some members of her group, this adds support for running a container on the mybinder.org service. It installs all of the dependencies of this project and enables anyone to run most of the demo notebooks. You can test this pre-merge by launching from my repo, https://mybinder.org/v2/gh/ryanlovett/iterative-Random-Forest/binder.